### PR TITLE
add support for specifying xml schema urls

### DIFF
--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -22,7 +22,10 @@
 package edu.harvard.hul.ois.jhove.module;
 
 import java.io.*;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.*;
 import edu.harvard.hul.ois.jhove.*;
@@ -115,8 +118,8 @@ public class XmlModule extends ModuleBase {
 	/* Hold the information needed to generate a textMD metadata fragment */
 	protected TextMDMetadata _textMD;
 
-	/* Map from URIs to locally stored schemas */
-	protected Map<String, File> _localSchemas;
+	/* Map from URIs to local schema overrides */
+	protected Map<String, URI> _localSchemas;
 
 	/******************************************************************
 	 * CLASS CONSTRUCTOR.
@@ -1024,8 +1027,8 @@ public class XmlModule extends ModuleBase {
 	}
 
 	/**
-	 * Add a mapping from a schema URI to a local file.
-	 * The parameter is of the form schema=[URI];[path]
+	 * Add a mapping from a schema URI to a local override.
+	 * The parameter is of the form schema=[URI];[URI]
 	 */
 	private void addLocalSchema(String param) {
 		int eq = param.indexOf('=');
@@ -1033,10 +1036,7 @@ public class XmlModule extends ModuleBase {
 		try {
 			String uri = param.substring(eq + 1, semi).trim();
 			String path = param.substring(semi + 1).trim();
-			File f = new File(path);
-			if (f.exists()) {
-				_localSchemas.put(uri, f);
-			}
+			_localSchemas.put(uri.toLowerCase(), URI.create(path));
 		} catch (Exception e) {
 		}
 	}

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/DTDMapper.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/DTDMapper.java
@@ -25,10 +25,22 @@ public class DTDMapper {
     private final static String xhtml1Strict = "-//W3C//DTD XHTML 1.0 STRICT//EN";
     private final static String xhtml1Transitional = "-//W3C//DTD XHTML 1.0 TRANSITIONAL//EN";
     private final static String xhtml11 = "-//W3C//DTD XHTML 1.1//EN";
+
+    private final static String xmlSchema10 = "-//W3C//DTD XMLSCHEMA 200102//EN";
+    private final static String xmlSchemaDatatypes10 = "DATATYPES";
+    private final static String xmlSchema11 = "-//W3C//DTD XSD 1.1//EN";
+    private final static String xmlSchemaDatatypes11 = "-//W3C//DTD XSD 1.1 Datatypes//EN";
+
     private final static String latin1Ent = "-//W3C//ENTITIES LATIN 1 FOR XHTML//EN";
     private final static String specialEnt = "-//W3C//ENTITIES SPECIAL FOR XHTML//EN";
     private final static String symbolEnt = "-//W3C//ENTITIES SYMBOLS FOR XHTML//EN";
-    
+
+    private final static String xmlDtdLocation = "edu/harvard/hul/ois/jhove/module/xml/";
+    private final static String xmlSchema10DtdLocation = xmlDtdLocation + "XMLSchema-1.0.dtd";
+    private final static String xmlSchemaDatatypes10DtdLocation = xmlDtdLocation + "XMLSchema-datatypes-1.0.dtd";
+    private final static String xmlSchema11DtdLocation = xmlDtdLocation + "XMLSchema-1.1.dtd";
+    private final static String xmlSchemaDatatypes11DtdLocation = xmlDtdLocation + "XMLSchema-datatypes-1.1.dtd";
+
     /** Attempts to convert a public ID to a matching DTD or Entity resource.
      *  Returns an InputStream for that resource if there is a match.  
      *  Otherwise returns <code>null</code>.
@@ -63,6 +75,14 @@ public class DTDMapper {
         }
         else if (symbolEnt.equals (publicID)) {
             filename = "xhtml-symbol.ent";
+        } else if (xmlSchema10.equals(publicID)) {
+            filename = xmlSchema10DtdLocation;
+        } else if (xmlSchemaDatatypes10.equals(publicID)) {
+            filename = xmlSchemaDatatypes10DtdLocation;
+        } else if (xmlSchema11.equals(publicID)) {
+            filename = xmlSchema11DtdLocation;
+        } else if (xmlSchemaDatatypes11.equals(publicID)) {
+            filename = xmlSchemaDatatypes11DtdLocation;
         }
         if (filename != null) {
             ClassLoader classLoader = ClassLoader.getSystemClassLoader();

--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-1.0.dtd
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-1.0.dtd
@@ -1,0 +1,402 @@
+<!-- DTD for XML Schemas: Part 1: Structures
+     Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
+     Official Location: http://www.w3.org/2001/XMLSchema.dtd -->
+        <!-- $Id: XMLSchema.dtd,v 1.31 2001/10/24 15:50:16 ht Exp $ -->
+        <!-- Note this DTD is NOT normative, or even definitive. -->           <!--d-->
+        <!-- prose copy in the structures REC is the definitive version -->    <!--d-->
+        <!-- (which shouldn't differ from this one except for this -->         <!--d-->
+        <!-- comment and entity expansions, but just in case) -->              <!--d-->
+        <!-- With the exception of cases with multiple namespace
+             prefixes for the XML Schema namespace, any XML document which is
+             not valid per this DTD given redefinitions in its internal subset of the
+             'p' and 's' parameter entities below appropriate to its namespace
+             declaration of the XML Schema namespace is almost certainly not
+             a valid schema. -->
+
+        <!-- The simpleType element and its constituent parts
+             are defined in XML Schema: Part 2: Datatypes -->
+        <!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' >
+
+        <!ENTITY % p 'xs:'> <!-- can be overriden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+        <!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+        <!ENTITY % nds 'xmlns%s;'>
+
+        <!-- Define all the element names, with optional prefix -->
+        <!ENTITY % schema "%p;schema">
+        <!ENTITY % complexType "%p;complexType">
+        <!ENTITY % complexContent "%p;complexContent">
+        <!ENTITY % simpleContent "%p;simpleContent">
+        <!ENTITY % extension "%p;extension">
+        <!ENTITY % element "%p;element">
+        <!ENTITY % unique "%p;unique">
+        <!ENTITY % key "%p;key">
+        <!ENTITY % keyref "%p;keyref">
+        <!ENTITY % selector "%p;selector">
+        <!ENTITY % field "%p;field">
+        <!ENTITY % group "%p;group">
+        <!ENTITY % all "%p;all">
+        <!ENTITY % choice "%p;choice">
+        <!ENTITY % sequence "%p;sequence">
+        <!ENTITY % any "%p;any">
+        <!ENTITY % anyAttribute "%p;anyAttribute">
+        <!ENTITY % attribute "%p;attribute">
+        <!ENTITY % attributeGroup "%p;attributeGroup">
+        <!ENTITY % include "%p;include">
+        <!ENTITY % import "%p;import">
+        <!ENTITY % redefine "%p;redefine">
+        <!ENTITY % notation "%p;notation">
+
+        <!-- annotation elements -->
+        <!ENTITY % annotation "%p;annotation">
+        <!ENTITY % appinfo "%p;appinfo">
+        <!ENTITY % documentation "%p;documentation">
+
+        <!-- Customisation entities for the ATTLIST of each element type.
+             Define one of these if your schema takes advantage of the
+             anyAttribute='##other' in the schema for schemas -->
+
+        <!ENTITY % schemaAttrs ''>
+        <!ENTITY % complexTypeAttrs ''>
+        <!ENTITY % complexContentAttrs ''>
+        <!ENTITY % simpleContentAttrs ''>
+        <!ENTITY % extensionAttrs ''>
+        <!ENTITY % elementAttrs ''>
+        <!ENTITY % groupAttrs ''>
+        <!ENTITY % allAttrs ''>
+        <!ENTITY % choiceAttrs ''>
+        <!ENTITY % sequenceAttrs ''>
+        <!ENTITY % anyAttrs ''>
+        <!ENTITY % anyAttributeAttrs ''>
+        <!ENTITY % attributeAttrs ''>
+        <!ENTITY % attributeGroupAttrs ''>
+        <!ENTITY % uniqueAttrs ''>
+        <!ENTITY % keyAttrs ''>
+        <!ENTITY % keyrefAttrs ''>
+        <!ENTITY % selectorAttrs ''>
+        <!ENTITY % fieldAttrs ''>
+        <!ENTITY % includeAttrs ''>
+        <!ENTITY % importAttrs ''>
+        <!ENTITY % redefineAttrs ''>
+        <!ENTITY % notationAttrs ''>
+        <!ENTITY % annotationAttrs ''>
+        <!ENTITY % appinfoAttrs ''>
+        <!ENTITY % documentationAttrs ''>
+
+        <!ENTITY % complexDerivationSet "CDATA">
+        <!-- #all or space-separated list drawn from derivationChoice -->
+        <!ENTITY % blockSet "CDATA">
+        <!-- #all or space-separated list drawn from
+                        derivationChoice + 'substitution' -->
+
+        <!ENTITY % mgs '%all; | %choice; | %sequence;'>
+        <!ENTITY % cs '%choice; | %sequence;'>
+        <!ENTITY % formValues '(qualified|unqualified)'>
+
+
+        <!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+        <!ENTITY % particleAndAttrs '((%mgs; | %group;)?, %attrDecls;)'>
+
+        <!-- This is used in part2 -->
+        <!ENTITY % restriction1 '((%mgs; | %group;)?)'>
+
+        %xs-datatypes;
+
+        <!-- the duplication below is to produce an unambiguous content model
+             which allows annotation everywhere -->
+        <!ELEMENT %schema; ((%include; | %import; | %redefine; | %annotation;)*,
+                ((%simpleType; | %complexType;
+                        | %element; | %attribute;
+                        | %attributeGroup; | %group;
+                        | %notation; ),
+                        (%annotation;)*)* )>
+        <!ATTLIST %schema;
+                targetNamespace      %URIref;               #IMPLIED
+                version              CDATA                  #IMPLIED
+                %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+                xmlns                CDATA                  #IMPLIED
+                finalDefault         %complexDerivationSet; ''
+                blockDefault         %blockSet;             ''
+                id                   ID                     #IMPLIED
+                elementFormDefault   %formValues;           'unqualified'
+                attributeFormDefault %formValues;           'unqualified'
+                xml:lang             CDATA                  #IMPLIED
+                %schemaAttrs;>
+        <!-- Note the xmlns declaration is NOT in the Schema for Schemas,
+             because at the Infoset level where schemas operate,
+             xmlns(:prefix) is NOT an attribute! -->
+        <!-- The declaration of xmlns is a convenience for schema authors -->
+
+        <!-- The id attribute here and below is for use in external references
+             from non-schemas using simple fragment identifiers.
+             It is NOT used for schema-to-schema reference, internal or
+             external. -->
+
+        <!-- a type is a named content type specification which allows attribute
+             declarations-->
+        <!-- -->
+
+        <!ELEMENT %complexType; ((%annotation;)?,
+                (%simpleContent;|%complexContent;|
+                        %particleAndAttrs;))>
+
+        <!ATTLIST %complexType;
+                name      %NCName;                        #IMPLIED
+                id        ID                              #IMPLIED
+                abstract  %boolean;                       #IMPLIED
+                final     %complexDerivationSet;          #IMPLIED
+                block     %complexDerivationSet;          #IMPLIED
+                mixed (true|false) 'false'
+                %complexTypeAttrs;>
+
+        <!-- particleAndAttrs is shorthand for a root type -->
+        <!-- mixed is disallowed if simpleContent, overriden if complexContent
+             has one too. -->
+
+        <!-- If anyAttribute appears in one or more referenced attributeGroups
+             and/or explicitly, the intersection of the permissions is used -->
+
+        <!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+        <!ATTLIST %complexContent;
+                mixed (true|false) #IMPLIED
+                id    ID           #IMPLIED
+                %complexContentAttrs;>
+
+        <!-- restriction should use the branch defined above, not the simple
+             one from part2; extension should use the full model  -->
+
+        <!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+        <!ATTLIST %simpleContent;
+                id    ID           #IMPLIED
+                %simpleContentAttrs;>
+
+        <!-- restriction should use the simple branch from part2, not the
+             one defined above; extension should have no particle  -->
+
+        <!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+        <!ATTLIST %extension;
+                base  %QName;      #REQUIRED
+                id    ID           #IMPLIED
+                %extensionAttrs;>
+
+        <!-- an element is declared by either:
+         a name and a type (either nested or referenced via the type attribute)
+         or a ref to an existing element declaration -->
+
+        <!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                (%unique; | %key; | %keyref;)*)>
+        <!-- simpleType or complexType only if no type|ref attribute -->
+        <!-- ref not allowed at top level -->
+        <!ATTLIST %element;
+                name               %NCName;               #IMPLIED
+                id                 ID                     #IMPLIED
+                ref                %QName;                #IMPLIED
+                type               %QName;                #IMPLIED
+                minOccurs          %nonNegativeInteger;   #IMPLIED
+                maxOccurs          CDATA                  #IMPLIED
+                nillable           %boolean;              #IMPLIED
+                substitutionGroup  %QName;                #IMPLIED
+                abstract           %boolean;              #IMPLIED
+                final              %complexDerivationSet; #IMPLIED
+                block              %blockSet;             #IMPLIED
+                default            CDATA                  #IMPLIED
+                fixed              CDATA                  #IMPLIED
+                form               %formValues;           #IMPLIED
+                %elementAttrs;>
+        <!-- type and ref are mutually exclusive.
+             name and ref are mutually exclusive, one is required -->
+        <!-- In the absence of type AND ref, type defaults to type of
+             substitutionGroup, if any, else the ur-type, i.e. unconstrained -->
+        <!-- default and fixed are mutually exclusive -->
+
+        <!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+        <!ATTLIST %group;
+                name        %NCName;               #IMPLIED
+                ref         %QName;                #IMPLIED
+                minOccurs   %nonNegativeInteger;   #IMPLIED
+                maxOccurs   CDATA                  #IMPLIED
+                id          ID                     #IMPLIED
+                %groupAttrs;>
+
+        <!ELEMENT %all; ((%annotation;)?, (%element;)*)>
+        <!ATTLIST %all;
+                minOccurs   (1)                    #IMPLIED
+                maxOccurs   (1)                    #IMPLIED
+                id          ID                     #IMPLIED
+                %allAttrs;>
+
+        <!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+        <!ATTLIST %choice;
+                minOccurs   %nonNegativeInteger;   #IMPLIED
+                maxOccurs   CDATA                  #IMPLIED
+                id          ID                     #IMPLIED
+                %choiceAttrs;>
+
+        <!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+        <!ATTLIST %sequence;
+                minOccurs   %nonNegativeInteger;   #IMPLIED
+                maxOccurs   CDATA                  #IMPLIED
+                id          ID                     #IMPLIED
+                %sequenceAttrs;>
+
+        <!-- an anonymous grouping in a model, or
+             a top-level named group definition, or a reference to same -->
+
+        <!-- Note that if order is 'all', group is not allowed inside.
+             If order is 'all' THIS group must be alone (or referenced alone) at
+             the top level of a content model -->
+        <!-- If order is 'all', minOccurs==maxOccurs==1 on element/any inside -->
+        <!-- Should allow minOccurs=0 inside order='all' . . . -->
+
+        <!ELEMENT %any; (%annotation;)?>
+        <!ATTLIST %any;
+                namespace       CDATA                  '##any'
+                processContents (skip|lax|strict)      'strict'
+                minOccurs       %nonNegativeInteger;   '1'
+                maxOccurs       CDATA                  '1'
+                id              ID                     #IMPLIED
+                %anyAttrs;>
+
+        <!-- namespace is interpreted as follows:
+                          ##any      - - any non-conflicting WFXML at all
+
+                          ##other    - - any non-conflicting WFXML from namespace other
+                                          than targetNamespace
+
+                          ##local    - - any unqualified non-conflicting WFXML/attribute
+                          one or     - - any non-conflicting WFXML from
+                          more URI        the listed namespaces
+                          references
+
+                          ##targetNamespace ##local may appear in the above list,
+                            with the obvious meaning -->
+
+        <!ELEMENT %anyAttribute; (%annotation;)?>
+        <!ATTLIST %anyAttribute;
+                namespace       CDATA              '##any'
+                processContents (skip|lax|strict)  'strict'
+                id              ID                 #IMPLIED
+                %anyAttributeAttrs;>
+        <!-- namespace is interpreted as for 'any' above -->
+
+        <!-- simpleType only if no type|ref attribute -->
+        <!-- ref not allowed at top level, name iff at top level -->
+        <!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+        <!ATTLIST %attribute;
+                name      %NCName;      #IMPLIED
+                id        ID            #IMPLIED
+                ref       %QName;       #IMPLIED
+                type      %QName;       #IMPLIED
+                use       (prohibited|optional|required) #IMPLIED
+                default   CDATA         #IMPLIED
+                fixed     CDATA         #IMPLIED
+                form      %formValues;  #IMPLIED
+                %attributeAttrs;>
+        <!-- type and ref are mutually exclusive.
+             name and ref are mutually exclusive, one is required -->
+        <!-- default for use is optional when nested, none otherwise -->
+        <!-- default and fixed are mutually exclusive -->
+        <!-- type attr and simpleType content are mutually exclusive -->
+
+        <!-- an attributeGroup is a named collection of attribute decls, or a
+             reference thereto -->
+        <!ELEMENT %attributeGroup; ((%annotation;)?,
+                (%attribute; | %attributeGroup;)*,
+                (%anyAttribute;)?) >
+        <!ATTLIST %attributeGroup;
+                name       %NCName;       #IMPLIED
+                id         ID             #IMPLIED
+                ref        %QName;        #IMPLIED
+                %attributeGroupAttrs;>
+
+        <!-- ref iff no content, no name.  ref iff not top level -->
+
+        <!-- better reference mechanisms -->
+        <!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+        <!ATTLIST %unique;
+                name     %NCName;       #REQUIRED
+                id       ID             #IMPLIED
+                %uniqueAttrs;>
+
+        <!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+        <!ATTLIST %key;
+                name     %NCName;       #REQUIRED
+                id       ID             #IMPLIED
+                %keyAttrs;>
+
+        <!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+        <!ATTLIST %keyref;
+                name     %NCName;       #REQUIRED
+                refer    %QName;        #REQUIRED
+                id       ID             #IMPLIED
+                %keyrefAttrs;>
+
+        <!ELEMENT %selector; ((%annotation;)?)>
+        <!ATTLIST %selector;
+                xpath %XPathExpr; #REQUIRED
+                id    ID          #IMPLIED
+                %selectorAttrs;>
+        <!ELEMENT %field; ((%annotation;)?)>
+        <!ATTLIST %field;
+                xpath %XPathExpr; #REQUIRED
+                id    ID          #IMPLIED
+                %fieldAttrs;>
+
+        <!-- Schema combination mechanisms -->
+        <!ELEMENT %include; (%annotation;)?>
+        <!ATTLIST %include;
+                schemaLocation %URIref; #REQUIRED
+                id             ID       #IMPLIED
+                %includeAttrs;>
+
+        <!ELEMENT %import; (%annotation;)?>
+        <!ATTLIST %import;
+                namespace      %URIref; #IMPLIED
+                schemaLocation %URIref; #IMPLIED
+                id             ID       #IMPLIED
+                %importAttrs;>
+
+        <!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                %attributeGroup; | %group;)*>
+        <!ATTLIST %redefine;
+                schemaLocation %URIref; #REQUIRED
+                id             ID       #IMPLIED
+                %redefineAttrs;>
+
+        <!ELEMENT %notation; (%annotation;)?>
+        <!ATTLIST %notation;
+                name        %NCName;    #REQUIRED
+                id          ID          #IMPLIED
+                public      CDATA       #REQUIRED
+                system      %URIref;    #IMPLIED
+                %notationAttrs;>
+
+        <!-- Annotation is either application information or documentation -->
+        <!-- By having these here they are available for datatypes as well
+             as all the structures elements -->
+
+        <!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+        <!ATTLIST %annotation; %annotationAttrs;>
+
+        <!-- User must define annotation elements in internal subset for this
+             to work -->
+        <!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+        <!ATTLIST %appinfo;
+                source     %URIref;      #IMPLIED
+                id         ID         #IMPLIED
+                %appinfoAttrs;>
+        <!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+        <!ATTLIST %documentation;
+                source     %URIref;   #IMPLIED
+                id         ID         #IMPLIED
+                xml:lang   CDATA      #IMPLIED
+                %documentationAttrs;>
+
+        <!NOTATION XMLSchemaStructures PUBLIC
+                'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+        <!NOTATION XML PUBLIC
+                'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >

--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-1.1.dtd
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-1.1.dtd
@@ -1,0 +1,514 @@
+
+<!-- DTD for XML Schema Definition Language Part 1: Structures
+     Public Identifier: "-//W3C//DTD XSD 1.1//EN"
+     Official Location: http://www.w3.org/2009/XMLSchema/XMLSchema.dtd -->
+        <!-- Id: structures.dtd,v 1.1 2003/08/28 13:30:52 ht Exp  -->
+        <!-- With the exception of cases with multiple namespace
+             prefixes for the XSD namespace, any XML document which is
+             not valid per this DTD given redefinitions in its internal subset of the
+             'p' and 's' parameter entities below appropriate to its namespace
+             declaration of the XSD namespace is almost certainly not
+             a valid schema document. -->
+
+        <!-- See below (at the bottom of this document) for information about
+              the revision and namespace-versioning policy governing this DTD. -->
+        <!-- The simpleType element and its constituent parts
+             are defined in XML Schema Definition Language Part 2: Datatypes -->
+        <!ENTITY % xs-datatypes PUBLIC '-//W3C//DTD XSD 1.1 Datatypes//EN' 'datatypes.dtd' >
+
+        <!ENTITY % p 'xs:'> <!-- can be overridden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+        <!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+        <!ENTITY % nds 'xmlns%s;'>
+
+        <!-- Define all the element names, with optional prefix -->
+        <!ENTITY % schema "%p;schema">
+        <!ENTITY % defaultOpenContent "%p;defaultOpenContent">
+        <!ENTITY % complexType "%p;complexType">
+        <!ENTITY % complexContent "%p;complexContent">
+        <!ENTITY % openContent "%p;openContent">
+        <!ENTITY % simpleContent "%p;simpleContent">
+        <!ENTITY % extension "%p;extension">
+        <!ENTITY % element "%p;element">
+        <!ENTITY % alternative "%p;alternative">
+        <!ENTITY % unique "%p;unique">
+        <!ENTITY % key "%p;key">
+        <!ENTITY % keyref "%p;keyref">
+        <!ENTITY % selector "%p;selector">
+        <!ENTITY % field "%p;field">
+        <!ENTITY % group "%p;group">
+        <!ENTITY % all "%p;all">
+        <!ENTITY % choice "%p;choice">
+        <!ENTITY % sequence "%p;sequence">
+        <!ENTITY % any "%p;any">
+        <!ENTITY % anyAttribute "%p;anyAttribute">
+        <!ENTITY % attribute "%p;attribute">
+        <!ENTITY % attributeGroup "%p;attributeGroup">
+        <!ENTITY % include "%p;include">
+        <!ENTITY % import "%p;import">
+        <!ENTITY % redefine "%p;redefine">
+        <!ENTITY % override "%p;override">
+        <!ENTITY % notation "%p;notation">
+        <!ENTITY % assert   "%p;assert">
+
+
+        <!-- annotation elements -->
+        <!ENTITY % annotation "%p;annotation">
+        <!ENTITY % appinfo "%p;appinfo">
+        <!ENTITY % documentation "%p;documentation">
+
+        <!-- Customisation entities for the ATTLIST of each element type.
+             Define one of these if your schema takes advantage of the
+             anyAttribute='##other' in the
+             schema for schema documents -->
+
+        <!ENTITY % schemaAttrs ''>
+        <!ENTITY % defaultOpenContentAttrs ''>
+        <!ENTITY % complexTypeAttrs ''>
+        <!ENTITY % complexContentAttrs ''>
+        <!ENTITY % openContentAttrs ''>
+        <!ENTITY % simpleContentAttrs ''>
+        <!ENTITY % extensionAttrs ''>
+        <!ENTITY % elementAttrs ''>
+        <!ENTITY % groupAttrs ''>
+        <!ENTITY % allAttrs ''>
+        <!ENTITY % choiceAttrs ''>
+        <!ENTITY % sequenceAttrs ''>
+        <!ENTITY % anyAttrs ''>
+        <!ENTITY % anyAttributeAttrs ''>
+        <!ENTITY % attributeAttrs ''>
+        <!ENTITY % attributeGroupAttrs ''>
+        <!ENTITY % uniqueAttrs ''>
+        <!ENTITY % keyAttrs ''>
+        <!ENTITY % keyrefAttrs ''>
+        <!ENTITY % selectorAttrs ''>
+        <!ENTITY % fieldAttrs ''>
+        <!ENTITY % assertAttrs ''>
+
+        <!ENTITY % includeAttrs ''>
+        <!ENTITY % importAttrs ''>
+        <!ENTITY % redefineAttrs ''>
+        <!ENTITY % overrideAttrs ''>
+        <!ENTITY % notationAttrs ''>
+        <!ENTITY % annotationAttrs ''>
+        <!ENTITY % appinfoAttrs ''>
+        <!ENTITY % documentationAttrs ''>
+
+        <!ENTITY % complexDerivationSet "CDATA">
+        <!-- #all or space-separated list drawn from derivationChoice -->
+        <!ENTITY % blockSet "CDATA">
+        <!-- #all or space-separated list drawn from
+                        derivationChoice + 'substitution' -->
+
+        <!ENTITY % composition '%include; | %import; | %override; | %redefine;'>
+        <!ENTITY % mgs '%all; | %choice; | %sequence;'>
+        <!ENTITY % cs '%choice; | %sequence;'>
+        <!ENTITY % formValues '(qualified|unqualified)'>
+
+
+        <!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+        <!ENTITY % assertions   '(%assert;)*'>
+
+        <!ENTITY % particleAndAttrs '(%openContent;?, (%mgs; | %group;)?,
+                              %attrDecls;, %assertions;)'>
+
+        <!-- This is used in part2 -->
+        <!ENTITY % restriction1 '(%openContent;?, (%mgs; | %group;)?)'>
+
+        %xs-datatypes;
+
+        <!-- the duplication below is to produce an unambiguous content model
+             which allows annotation everywhere -->
+        <!ELEMENT %schema; ((%composition; | %annotation;)*,
+                (%defaultOpenContent;, (%annotation;)*)?,
+                ((%simpleType; | %complexType;
+                        | %element; | %attribute;
+                        | %attributeGroup; | %group;
+                        | %notation; ),
+                        (%annotation;)*)* )>
+        <!ATTLIST %schema;
+                targetNamespace      %URIref;               #IMPLIED
+                version              CDATA                  #IMPLIED
+                %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+                xmlns                CDATA                  #IMPLIED
+                finalDefault         %complexDerivationSet; ''
+                blockDefault         %blockSet;             ''
+                id                   ID                     #IMPLIED
+                elementFormDefault   %formValues;           'unqualified'
+                attributeFormDefault %formValues;           'unqualified'
+                defaultAttributes    CDATA                  #IMPLIED
+                xpathDefaultNamespace    CDATA       '##local'
+                xml:lang             CDATA                  #IMPLIED
+                %schemaAttrs;>
+        <!-- Note the xmlns declaration is NOT in the
+             schema for schema documents,
+             because at the Infoset level where schemas operate,
+             xmlns(:prefix) is NOT an attribute! -->
+        <!-- The declaration of xmlns is a convenience for schema authors -->
+
+        <!-- The id attribute here and below is for use in external references
+             from non-schemas using simple fragment identifiers.
+             It is NOT used for schema-to-schema reference, internal or
+             external. -->
+
+        <!ELEMENT %defaultOpenContent; ((%annotation;)?, %any;)>
+        <!ATTLIST %defaultOpenContent;
+                appliesToEmpty  (true|false)           'false'
+                mode            (interleave|suffix)    'interleave'
+                id              ID                     #IMPLIED
+                %defaultOpenContentAttrs;>
+
+        <!-- a type is a named content type specification which allows attribute
+             declarations-->
+        <!-- -->
+
+        <!ELEMENT %complexType; ((%annotation;)?,
+                (%simpleContent;|%complexContent;|
+                        %particleAndAttrs;))>
+
+        <!ATTLIST %complexType;
+                name                    %NCName;                 #IMPLIED
+                id                      ID                       #IMPLIED
+                abstract                %boolean;                #IMPLIED
+                final                   %complexDerivationSet;   #IMPLIED
+                block                   %complexDerivationSet;   #IMPLIED
+                mixed                   (true|false)             'false'
+                defaultAttributesApply  %boolean;                'true'
+                %complexTypeAttrs;>
+
+        <!-- particleAndAttrs is shorthand for a root type -->
+        <!-- mixed is disallowed if simpleContent, overridden if complexContent has one too. -->
+
+        <!-- If anyAttribute appears in one or more referenced attributeGroups
+             and/or explicitly, the intersection of the permissions is used -->
+
+        <!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+        <!ATTLIST %complexContent;
+                mixed (true|false) #IMPLIED
+                id    ID           #IMPLIED
+                %complexContentAttrs;>
+
+        <!ELEMENT %openContent; ((%annotation;)?, (%any;)?)>
+        <!ATTLIST %openContent;
+                mode            (none|interleave|suffix)  'interleave'
+                id              ID                        #IMPLIED
+                %openContentAttrs;>
+
+        <!-- restriction should use the branch defined above, not the simple
+             one from part2; extension should use the full model  -->
+
+        <!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+        <!ATTLIST %simpleContent;
+                id    ID           #IMPLIED
+                %simpleContentAttrs;>
+
+        <!-- restriction should use the simple branch from part2, not the
+             one defined above; extension should have no particle  -->
+
+        <!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+        <!ATTLIST %extension;
+                base  %QName;               #REQUIRED
+                id    ID                    #IMPLIED
+
+                %extensionAttrs;>
+
+        <!-- an element is declared by either:
+         a name and a type (either nested or referenced via the type attribute)
+         or a ref to an existing element declaration -->
+
+        <!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                (%alternative;)*,
+                (%unique; | %key; | %keyref;)*)>
+        <!-- simpleType or complexType only if no type|ref attribute -->
+        <!-- ref not allowed at top level -->
+        <!ATTLIST %element;
+                name               %NCName;               #IMPLIED
+                id                 ID                     #IMPLIED
+                ref                %QName;                #IMPLIED
+                type               %QName;                #IMPLIED
+                minOccurs          %nonNegativeInteger;   #IMPLIED
+                maxOccurs          CDATA                  #IMPLIED
+                nillable           %boolean;              #IMPLIED
+                substitutionGroup  %QName;                #IMPLIED
+                abstract           %boolean;              #IMPLIED
+                final              %complexDerivationSet; #IMPLIED
+                block              %blockSet;             #IMPLIED
+                default            CDATA                  #IMPLIED
+                fixed              CDATA                  #IMPLIED
+                form               %formValues;           #IMPLIED
+                targetNamespace    %URIref;               #IMPLIED
+                %elementAttrs;>
+        <!-- type and ref are mutually exclusive.
+             name and ref are mutually exclusive, one is required -->
+        <!-- In the absence of type AND ref, type defaults to type of
+             substitutionGroup, if any, else xs:anyType, i.e. unconstrained -->
+        <!-- default and fixed are mutually exclusive -->
+
+        <!ELEMENT %alternative; ((%annotation;)?,
+                (%simpleType; | %complexType;)?) >
+        <!ATTLIST %alternative;
+                test                     CDATA     #IMPLIED
+                type                     %QName;   #IMPLIED
+                xpathDefaultNamespace    CDATA     #IMPLIED
+                id                       ID        #IMPLIED >
+
+
+        <!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+        <!ATTLIST %group;
+                name        %NCName;               #IMPLIED
+                ref         %QName;                #IMPLIED
+                minOccurs   %nonNegativeInteger;   #IMPLIED
+                maxOccurs   CDATA                  #IMPLIED
+                id          ID                     #IMPLIED
+                %groupAttrs;>
+
+        <!ELEMENT %all; ((%annotation;)?, (%element;| %group;| %any;)*)>
+        <!ATTLIST %all;
+                minOccurs   (0 | 1)                #IMPLIED
+                maxOccurs   (0 | 1)                #IMPLIED
+                id          ID                     #IMPLIED
+                %allAttrs;>
+
+        <!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+        <!ATTLIST %choice;
+                minOccurs   %nonNegativeInteger;   #IMPLIED
+                maxOccurs   CDATA                  #IMPLIED
+                id          ID                     #IMPLIED
+                %choiceAttrs;>
+
+        <!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+        <!ATTLIST %sequence;
+                minOccurs   %nonNegativeInteger;   #IMPLIED
+                maxOccurs   CDATA                  #IMPLIED
+                id          ID                     #IMPLIED
+                %sequenceAttrs;>
+
+        <!-- an anonymous grouping in a model, or
+             a top-level named group definition, or a reference to same -->
+
+
+        <!ELEMENT %any; (%annotation;)?>
+        <!ATTLIST %any;
+                namespace       CDATA                  #IMPLIED
+                notNamespace    CDATA                  #IMPLIED
+                notQName        CDATA                  ''
+                processContents (skip|lax|strict)      'strict'
+                minOccurs       %nonNegativeInteger;   '1'
+                maxOccurs       CDATA                  '1'
+                id              ID                     #IMPLIED
+                %anyAttrs;>
+
+        <!-- namespace is interpreted as follows:
+                          ##any      - - any non-conflicting WFXML at all
+
+                          ##other    - - any non-conflicting WFXML from namespace other
+                                          than targetNamespace
+
+                          ##local    - - any unqualified non-conflicting WFXML/attribute
+                          one or     - - any non-conflicting WFXML from
+                          more URI        the listed namespaces
+                          references
+
+                          ##targetNamespace ##local may appear in the above list,
+                            with the obvious meaning -->
+
+        <!-- notNamespace is interpreted as follows:
+                          ##local    - - any unqualified non-conflicting WFXML/attribute
+                          one or     - - any non-conflicting WFXML from
+                          more URI        the listed namespaces
+                          references
+
+                          ##targetNamespace ##local may appear in the above list,
+                            with the obvious meaning -->
+
+        <!ELEMENT %anyAttribute; (%annotation;)?>
+        <!ATTLIST %anyAttribute;
+                namespace       CDATA              #IMPLIED
+                notNamespace    CDATA              #IMPLIED
+                notQName        CDATA              ''
+                processContents (skip|lax|strict)  'strict'
+                id              ID                 #IMPLIED
+                %anyAttributeAttrs;>
+        <!-- namespace and notNamespace are interpreted as for 'any' above -->
+
+        <!-- simpleType only if no type|ref attribute -->
+        <!-- ref not allowed at top level, name iff at top level -->
+        <!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+        <!ATTLIST %attribute;
+                name              %NCName;      #IMPLIED
+                id                ID            #IMPLIED
+                ref               %QName;       #IMPLIED
+                type              %QName;       #IMPLIED
+                use               (prohibited|optional|required) #IMPLIED
+                default           CDATA         #IMPLIED
+                fixed             CDATA         #IMPLIED
+                form              %formValues;  #IMPLIED
+                targetNamespace   %URIref;      #IMPLIED
+                inheritable       %boolean;      #IMPLIED
+                %attributeAttrs;>
+        <!-- type and ref are mutually exclusive.
+             name and ref are mutually exclusive, one is required -->
+        <!-- default for use is optional when nested, none otherwise -->
+        <!-- default and fixed are mutually exclusive -->
+        <!-- type attr and simpleType content are mutually exclusive -->
+
+        <!-- an attributeGroup is a named collection of attribute decls, or a
+             reference thereto -->
+        <!ELEMENT %attributeGroup; ((%annotation;)?,
+                (%attribute; | %attributeGroup;)*,
+                (%anyAttribute;)?) >
+        <!ATTLIST %attributeGroup;
+                name       %NCName;       #IMPLIED
+                id         ID             #IMPLIED
+                ref        %QName;        #IMPLIED
+                %attributeGroupAttrs;>
+
+        <!-- ref iff no content, no name.  ref iff not top level -->
+
+        <!-- better reference mechanisms -->
+        <!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+        <!ATTLIST %unique;
+                name                     %NCName;       #IMPLIED
+                ref                      %QName;        #IMPLIED
+                id                       ID             #IMPLIED
+                %uniqueAttrs;>
+
+        <!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+        <!ATTLIST %key;
+                name                     %NCName;       #IMPLIED
+                ref                      %QName;        #IMPLIED
+                id                       ID             #IMPLIED
+                %keyAttrs;>
+
+        <!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+        <!ATTLIST %keyref;
+                name                     %NCName;       #IMPLIED
+                ref                      %QName;        #IMPLIED
+                refer                    %QName;        #IMPLIED
+                id                       ID             #IMPLIED
+                %keyrefAttrs;>
+
+        <!ELEMENT %selector; ((%annotation;)?)>
+        <!ATTLIST %selector;
+                xpath                    %XPathExpr; #REQUIRED
+                xpathDefaultNamespace    CDATA       #IMPLIED
+                id                       ID          #IMPLIED
+                %selectorAttrs;>
+        <!ELEMENT %field; ((%annotation;)?)>
+        <!ATTLIST %field;
+                xpath                    %XPathExpr; #REQUIRED
+                xpathDefaultNamespace    CDATA       #IMPLIED
+                id                       ID          #IMPLIED
+                %fieldAttrs;>
+
+        <!-- co-constraint assertions -->
+        <!ELEMENT %assert; ((%annotation;)?)>
+        <!ATTLIST %assert;
+                test                     %XPathExpr; #REQUIRED
+                id                       ID          #IMPLIED
+                xpathDefaultNamespace    CDATA       #IMPLIED
+                %assertAttrs;>
+
+
+        <!-- Schema combination mechanisms -->
+        <!ELEMENT %include; (%annotation;)?>
+        <!ATTLIST %include;
+                schemaLocation %URIref; #REQUIRED
+                id             ID       #IMPLIED
+                %includeAttrs;>
+
+        <!ELEMENT %import; (%annotation;)?>
+        <!ATTLIST %import;
+                namespace      %URIref; #IMPLIED
+                schemaLocation %URIref; #IMPLIED
+                id             ID       #IMPLIED
+                %importAttrs;>
+
+        <!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                %attributeGroup; | %group;)*>
+        <!ATTLIST %redefine;
+                schemaLocation %URIref; #REQUIRED
+                id             ID       #IMPLIED
+                %redefineAttrs;>
+
+        <!ELEMENT %override; ((%annotation;)?,
+                ((%simpleType; | %complexType; | %group; | %attributeGroup;) |
+                        %element; | %attribute; | %notation;)*)>
+        <!ATTLIST %override;
+                schemaLocation %URIref; #REQUIRED
+                id             ID       #IMPLIED
+                %overrideAttrs;>
+
+        <!ELEMENT %notation; (%annotation;)?>
+        <!ATTLIST %notation;
+                name        %NCName;    #REQUIRED
+                id          ID          #IMPLIED
+                public      CDATA       #REQUIRED
+                system      %URIref;    #IMPLIED
+                %notationAttrs;>
+
+        <!-- Annotation is either application information or documentation -->
+        <!-- By having these here they are available for datatypes as well
+             as all the structures elements -->
+
+        <!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+        <!ATTLIST %annotation; %annotationAttrs;>
+
+        <!-- User must define annotation elements in internal subset for this
+             to work -->
+        <!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+        <!ATTLIST %appinfo;
+                source     %URIref;      #IMPLIED
+                id         ID         #IMPLIED
+                %appinfoAttrs;>
+        <!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+        <!ATTLIST %documentation;
+                source     %URIref;   #IMPLIED
+                id         ID         #IMPLIED
+                xml:lang   CDATA      #IMPLIED
+                %documentationAttrs;>
+
+        <!NOTATION XMLSchemaStructures PUBLIC
+                'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+        <!NOTATION XML PUBLIC
+                'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >
+
+        <!--
+              In keeping with the XML Schema WG's standard versioning policy,
+              this DTD will persist at the URI
+              http://www.w3.org/2012/04/XMLSchema.dtd.
+
+              At the date of issue it can also be found at the URI
+              http://www.w3.org/2009/XMLSchema/XMLSchema.dtd.
+
+              The schema document at that URI may however change in the future,
+              in order to remain compatible with the latest version of XSD
+              and its namespace.  In other words, if XSD or the XML Schema
+              namespace change, the version of this document at
+              http://www.w3.org/2009/XMLSchema/XMLSchema.dtd will change accordingly;
+              the version at http://www.w3.org/2012/04/XMLSchema.dtd
+              will not change.
+
+              Previous dated (and unchanging) versions of this DTD include:
+
+               http://www.w3.org/2012/01/XMLSchema.dtd
+                  (XSD 1.1 Proposed Recommendation)
+
+
+                http://www.w3.org/2011/07/XMLSchema.dtd
+                  (XSD 1.1 Candidate Recommendation)
+
+                http://www.w3.org/2009/04/XMLSchema.dtd
+                  (XSD 1.1 Candidate Recommendation)
+
+                http://www.w3.org/2004/10/XMLSchema.dtd
+                  (XSD 1.0 Recommendation, Second Edition)
+
+                http://www.w3.org/2001/05/XMLSchema.dtd
+                  (XSD 1.0 Recommendation, First Edition)
+
+        -->

--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-datatypes-1.0.dtd
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-datatypes-1.0.dtd
@@ -1,0 +1,204 @@
+
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+        $Id: datatypes.dtd,v 1.23 2001/03/16 17:36:30 ht Exp $
+        Note this DTD is NOT normative, or even definitive. - - the
+        prose copy in the datatypes REC is the definitive version
+        (which shouldn't differ from this one except for this comment
+        and entity expansions, but just in case)
+  -->
+
+        <!--
+                This DTD cannot be used on its own, it is intended
+                only for incorporation in XMLSchema.dtd, q.v.
+          -->
+
+        <!-- Define all the element names, with optional prefix -->
+        <!ENTITY % simpleType "%p;simpleType">
+        <!ENTITY % restriction "%p;restriction">
+        <!ENTITY % list "%p;list">
+        <!ENTITY % union "%p;union">
+        <!ENTITY % maxExclusive "%p;maxExclusive">
+        <!ENTITY % minExclusive "%p;minExclusive">
+        <!ENTITY % maxInclusive "%p;maxInclusive">
+        <!ENTITY % minInclusive "%p;minInclusive">
+        <!ENTITY % totalDigits "%p;totalDigits">
+        <!ENTITY % fractionDigits "%p;fractionDigits">
+        <!ENTITY % length "%p;length">
+        <!ENTITY % minLength "%p;minLength">
+        <!ENTITY % maxLength "%p;maxLength">
+        <!ENTITY % enumeration "%p;enumeration">
+        <!ENTITY % whiteSpace "%p;whiteSpace">
+        <!ENTITY % pattern "%p;pattern">
+
+        <!--
+                Customisation entities for the ATTLIST of each element
+                type. Define one of these if your schema takes advantage
+                of the anyAttribute='##other' in the schema for schemas
+          -->
+
+        <!ENTITY % simpleTypeAttrs "">
+        <!ENTITY % restrictionAttrs "">
+        <!ENTITY % listAttrs "">
+        <!ENTITY % unionAttrs "">
+        <!ENTITY % maxExclusiveAttrs "">
+        <!ENTITY % minExclusiveAttrs "">
+        <!ENTITY % maxInclusiveAttrs "">
+        <!ENTITY % minInclusiveAttrs "">
+        <!ENTITY % totalDigitsAttrs "">
+        <!ENTITY % fractionDigitsAttrs "">
+        <!ENTITY % lengthAttrs "">
+        <!ENTITY % minLengthAttrs "">
+        <!ENTITY % maxLengthAttrs "">
+        <!ENTITY % enumerationAttrs "">
+        <!ENTITY % whiteSpaceAttrs "">
+        <!ENTITY % patternAttrs "">
+
+        <!-- Define some entities for informative use as attribute
+                types -->
+        <!ENTITY % URIref "CDATA">
+        <!ENTITY % XPathExpr "CDATA">
+        <!ENTITY % QName "NMTOKEN">
+        <!ENTITY % QNames "NMTOKENS">
+        <!ENTITY % NCName "NMTOKEN">
+        <!ENTITY % nonNegativeInteger "NMTOKEN">
+        <!ENTITY % boolean "(true|false)">
+        <!ENTITY % simpleDerivationSet "CDATA">
+        <!--
+                #all or space-separated list drawn from derivationChoice
+          -->
+
+        <!--
+                Note that the use of 'facet' below is less restrictive
+                than is really intended:  There should in fact be no
+                more than one of each of minInclusive, minExclusive,
+                maxInclusive, maxExclusive, totalDigits, fractionDigits,
+                length, maxLength, minLength within datatype,
+                and the min- and max- variants of Inclusive and Exclusive
+                are mutually exclusive. On the other hand,  pattern and
+                enumeration may repeat.
+          -->
+        <!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+        <!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+        <!ENTITY % bounds "%minBound; | %maxBound;">
+        <!ENTITY % numeric "%totalDigits; | %fractionDigits;">
+        <!ENTITY % ordered "%bounds; | %numeric;">
+        <!ENTITY % unordered
+                "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength;">
+        <!ENTITY % facet "%ordered; | %unordered;">
+        <!ENTITY % facetAttr
+                "value CDATA #REQUIRED
+        id ID #IMPLIED">
+        <!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+        <!ENTITY % facetModel "(%annotation;)?">
+        <!ELEMENT %simpleType;
+                ((%annotation;)?, (%restriction; | %list; | %union;))>
+        <!ATTLIST %simpleType;
+                name      %NCName; #IMPLIED
+                final     %simpleDerivationSet; #IMPLIED
+                id        ID       #IMPLIED
+                %simpleTypeAttrs;>
+        <!-- name is required at top level -->
+        <!ELEMENT %restriction; ((%annotation;)?,
+                (%restriction1; |
+                        ((%simpleType;)?,(%facet;)*)),
+                (%attrDecls;))>
+        <!ATTLIST %restriction;
+                base      %QName;                  #IMPLIED
+                id        ID       #IMPLIED
+                %restrictionAttrs;>
+        <!--
+                base and simpleType child are mutually exclusive,
+                one is required.
+
+                restriction is shared between simpleType and
+                simpleContent and complexContent (in XMLSchema.xsd).
+                restriction1 is for the latter cases, when this
+                is restricting a complex type, as is attrDecls.
+          -->
+        <!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+        <!ATTLIST %list;
+                itemType      %QName;             #IMPLIED
+                id        ID       #IMPLIED
+                %listAttrs;>
+        <!--
+                itemType and simpleType child are mutually exclusive,
+                one is required
+          -->
+        <!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+        <!ATTLIST %union;
+                id            ID       #IMPLIED
+                memberTypes   %QNames;            #IMPLIED
+                %unionAttrs;>
+        <!--
+                At least one item in memberTypes or one simpleType
+                child is required
+          -->
+
+        <!ELEMENT %maxExclusive; %facetModel;>
+        <!ATTLIST %maxExclusive;
+                %facetAttr;
+                %fixedAttr;
+                %maxExclusiveAttrs;>
+        <!ELEMENT %minExclusive; %facetModel;>
+        <!ATTLIST %minExclusive;
+                %facetAttr;
+                %fixedAttr;
+                %minExclusiveAttrs;>
+
+        <!ELEMENT %maxInclusive; %facetModel;>
+        <!ATTLIST %maxInclusive;
+                %facetAttr;
+                %fixedAttr;
+                %maxInclusiveAttrs;>
+        <!ELEMENT %minInclusive; %facetModel;>
+        <!ATTLIST %minInclusive;
+                %facetAttr;
+                %fixedAttr;
+                %minInclusiveAttrs;>
+
+        <!ELEMENT %totalDigits; %facetModel;>
+        <!ATTLIST %totalDigits;
+                %facetAttr;
+                %fixedAttr;
+                %totalDigitsAttrs;>
+        <!ELEMENT %fractionDigits; %facetModel;>
+        <!ATTLIST %fractionDigits;
+                %facetAttr;
+                %fixedAttr;
+                %fractionDigitsAttrs;>
+
+        <!ELEMENT %length; %facetModel;>
+        <!ATTLIST %length;
+                %facetAttr;
+                %fixedAttr;
+                %lengthAttrs;>
+        <!ELEMENT %minLength; %facetModel;>
+        <!ATTLIST %minLength;
+                %facetAttr;
+                %fixedAttr;
+                %minLengthAttrs;>
+        <!ELEMENT %maxLength; %facetModel;>
+        <!ATTLIST %maxLength;
+                %facetAttr;
+                %fixedAttr;
+                %maxLengthAttrs;>
+
+        <!-- This one can be repeated -->
+        <!ELEMENT %enumeration; %facetModel;>
+        <!ATTLIST %enumeration;
+                %facetAttr;
+                %enumerationAttrs;>
+
+        <!ELEMENT %whiteSpace; %facetModel;>
+        <!ATTLIST %whiteSpace;
+                %facetAttr;
+                %fixedAttr;
+                %whiteSpaceAttrs;>
+
+        <!-- This one can be repeated -->
+        <!ELEMENT %pattern; %facetModel;>
+        <!ATTLIST %pattern;
+                %facetAttr;
+                %patternAttrs;>

--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-datatypes-1.1.dtd
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/XMLSchema-datatypes-1.1.dtd
@@ -1,0 +1,223 @@
+
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+
+        Id: datatypes.dtd,v 1.1.2.4 2005/01/31 18:40:42 cmsmcq Exp
+        Note this DTD is NOT normative, or even definitive.
+  -->
+
+        <!--
+                This DTD cannot be used on its own, it is intended
+                only for incorporation in XMLSchema.dtd, q.v.
+          -->
+
+        <!-- Define all the element names, with optional prefix -->
+        <!ENTITY % simpleType "%p;simpleType">
+        <!ENTITY % restriction "%p;restriction">
+        <!ENTITY % list "%p;list">
+        <!ENTITY % union "%p;union">
+        <!ENTITY % maxExclusive "%p;maxExclusive">
+        <!ENTITY % minExclusive "%p;minExclusive">
+        <!ENTITY % maxInclusive "%p;maxInclusive">
+        <!ENTITY % minInclusive "%p;minInclusive">
+        <!ENTITY % totalDigits "%p;totalDigits">
+        <!ENTITY % fractionDigits "%p;fractionDigits">
+
+        <!ENTITY % length "%p;length">
+        <!ENTITY % minLength "%p;minLength">
+        <!ENTITY % maxLength "%p;maxLength">
+        <!ENTITY % enumeration "%p;enumeration">
+        <!ENTITY % whiteSpace "%p;whiteSpace">
+        <!ENTITY % pattern "%p;pattern">
+
+        <!ENTITY % assertion "%p;assertion">
+
+        <!ENTITY % explicitTimezone "%p;explicitTimezone">
+
+
+        <!--
+                Customization entities for the ATTLIST of each element
+                type. Define one of these if your schema takes advantage
+                of the anyAttribute='##other' in the schema for schemas
+          -->
+
+        <!ENTITY % simpleTypeAttrs "">
+        <!ENTITY % restrictionAttrs "">
+        <!ENTITY % listAttrs "">
+        <!ENTITY % unionAttrs "">
+        <!ENTITY % maxExclusiveAttrs "">
+        <!ENTITY % minExclusiveAttrs "">
+        <!ENTITY % maxInclusiveAttrs "">
+        <!ENTITY % minInclusiveAttrs "">
+        <!ENTITY % totalDigitsAttrs "">
+        <!ENTITY % fractionDigitsAttrs "">
+        <!ENTITY % lengthAttrs "">
+        <!ENTITY % minLengthAttrs "">
+        <!ENTITY % maxLengthAttrs "">
+
+        <!ENTITY % enumerationAttrs "">
+        <!ENTITY % whiteSpaceAttrs "">
+        <!ENTITY % patternAttrs "">
+        <!ENTITY % assertionAttrs "">
+        <!ENTITY % explicitTimezoneAttrs "">
+
+        <!-- Define some entities for informative use as attribute
+                types -->
+        <!ENTITY % URIref "CDATA">
+        <!ENTITY % XPathExpr "CDATA">
+        <!ENTITY % QName "NMTOKEN">
+        <!ENTITY % QNames "NMTOKENS">
+        <!ENTITY % NCName "NMTOKEN">
+        <!ENTITY % nonNegativeInteger "NMTOKEN">
+        <!ENTITY % boolean "(true|false)">
+        <!ENTITY % simpleDerivationSet "CDATA">
+        <!--
+                #all or space-separated list drawn from derivationChoice
+          -->
+
+        <!--
+                Note that the use of 'facet' below is less restrictive
+                than is really intended:  There should in fact be no
+                more than one of each of minInclusive, minExclusive,
+                maxInclusive, maxExclusive, totalDigits, fractionDigits,
+                length, maxLength, minLength within datatype,
+                and the min- and max- variants of Inclusive and Exclusive
+                are mutually exclusive. On the other hand,  pattern and
+                enumeration and assertion may repeat.
+          -->
+        <!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+        <!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+        <!ENTITY % bounds "%minBound; | %maxBound;">
+        <!ENTITY % numeric "%totalDigits; | %fractionDigits;">
+        <!ENTITY % ordered "%bounds; | %numeric;">
+        <!ENTITY % unordered
+                "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength; | %assertion;
+   | %explicitTimezone;">
+        <!ENTITY % implementation-defined-facets "">
+        <!ENTITY % facet "%ordered; | %unordered; %implementation-defined-facets;">
+        <!ENTITY % facetAttr
+                "value CDATA #REQUIRED
+        id ID #IMPLIED">
+        <!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+        <!ENTITY % facetModel "(%annotation;)?">
+        <!ELEMENT %simpleType;
+                ((%annotation;)?, (%restriction; | %list; | %union;))>
+        <!ATTLIST %simpleType;
+                name      %NCName; #IMPLIED
+                final     %simpleDerivationSet; #IMPLIED
+                id        ID       #IMPLIED
+                %simpleTypeAttrs;>
+        <!-- name is required at top level -->
+        <!ELEMENT %restriction; ((%annotation;)?,
+                (%restriction1; |
+                        ((%simpleType;)?,(%facet;)*)),
+                (%attrDecls;))>
+        <!ATTLIST %restriction;
+                base      %QName;                  #IMPLIED
+                id        ID       #IMPLIED
+                %restrictionAttrs;>
+        <!--
+                base and simpleType child are mutually exclusive,
+                one is required.
+
+                restriction is shared between simpleType and
+                simpleContent and complexContent (in XMLSchema.xsd).
+                restriction1 is for the latter cases, when this
+                is restricting a complex type, as is attrDecls.
+          -->
+        <!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+        <!ATTLIST %list;
+                itemType      %QName;             #IMPLIED
+                id        ID       #IMPLIED
+                %listAttrs;>
+        <!--
+                itemType and simpleType child are mutually exclusive,
+                one is required
+          -->
+        <!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+        <!ATTLIST %union;
+                id            ID       #IMPLIED
+                memberTypes   %QNames;            #IMPLIED
+                %unionAttrs;>
+        <!--
+                At least one item in memberTypes or one simpleType
+                child is required
+          -->
+
+        <!ELEMENT %maxExclusive; %facetModel;>
+        <!ATTLIST %maxExclusive;
+                %facetAttr;
+                %fixedAttr;
+                %maxExclusiveAttrs;>
+        <!ELEMENT %minExclusive; %facetModel;>
+        <!ATTLIST %minExclusive;
+                %facetAttr;
+                %fixedAttr;
+                %minExclusiveAttrs;>
+
+        <!ELEMENT %maxInclusive; %facetModel;>
+        <!ATTLIST %maxInclusive;
+                %facetAttr;
+                %fixedAttr;
+                %maxInclusiveAttrs;>
+        <!ELEMENT %minInclusive; %facetModel;>
+        <!ATTLIST %minInclusive;
+                %facetAttr;
+                %fixedAttr;
+                %minInclusiveAttrs;>
+
+        <!ELEMENT %totalDigits; %facetModel;>
+        <!ATTLIST %totalDigits;
+                %facetAttr;
+                %fixedAttr;
+                %totalDigitsAttrs;>
+        <!ELEMENT %fractionDigits; %facetModel;>
+        <!ATTLIST %fractionDigits;
+                %facetAttr;
+                %fixedAttr;
+                %fractionDigitsAttrs;>
+
+        <!ELEMENT %length; %facetModel;>
+        <!ATTLIST %length;
+                %facetAttr;
+                %fixedAttr;
+                %lengthAttrs;>
+        <!ELEMENT %minLength; %facetModel;>
+        <!ATTLIST %minLength;
+                %facetAttr;
+                %fixedAttr;
+                %minLengthAttrs;>
+        <!ELEMENT %maxLength; %facetModel;>
+        <!ATTLIST %maxLength;
+                %facetAttr;
+                %fixedAttr;
+                %maxLengthAttrs;>
+
+        <!-- This one can be repeated -->
+        <!ELEMENT %enumeration; %facetModel;>
+        <!ATTLIST %enumeration;
+                %facetAttr;
+                %enumerationAttrs;>
+
+        <!ELEMENT %whiteSpace; %facetModel;>
+        <!ATTLIST %whiteSpace;
+                %facetAttr;
+                %fixedAttr;
+                %whiteSpaceAttrs;>
+
+        <!-- This one can be repeated -->
+        <!ELEMENT %pattern; %facetModel;>
+        <!ATTLIST %pattern;
+                %facetAttr;
+                %patternAttrs;>
+
+        <!ELEMENT %assertion; %facetModel;>
+        <!ATTLIST %assertion;
+                %facetAttr;
+                %assertionAttrs;>
+
+        <!ELEMENT %explicitTimezone; %facetModel;>
+        <!ATTLIST %explicitTimezone;
+                %facetAttr;
+                %explicitTimezoneAttrs;>

--- a/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleTest.java
+++ b/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleTest.java
@@ -11,15 +11,28 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 
 public class XmlModuleTest {
 
     private static final String RESOURCE_DIR = "src/test/resources/edu/harvard/hul/ois/jhove/module/";
+    private static final String LOCAL_DC_SCHEMA_PATH = RESOURCE_DIR + "simpledc20021212.xsd";
+
     private static final String MODULE_NAME = "XML-hul";
     private static final int SIG_BYTES = 1024;
+
+    private static final URI DC_SCHEMA_URI = URI.create("http://dublincore.org/schemas/xmls/simpledc20021212.xsd");
+
+    private static final String DC_XML = "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\"" +
+            " xmlns:dc=\"http://purl.org/dc/elements/1.1/\"" +
+            " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+            " xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd\">\n" +
+            "  <dc:identifier>1234:example</dc:identifier>\n" +
+            "</oai_dc:dc>";
 
     private XmlModule module;
 
@@ -45,20 +58,16 @@ public class XmlModuleTest {
 
     @Test
     public void validateXmlSucceedsWhenHasRootSchema() {
-        String xml = "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\"" +
-                " xmlns:dc=\"http://purl.org/dc/elements/1.1/\"" +
-                " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
-                " xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd\">\n" +
-                "  <dc:identifier>1234:example</dc:identifier>\n" +
-                "</oai_dc:dc>";
         RepInfo info = new RepInfo("uri:test");
 
-        int parseIndex = module.parse(stream(xml), info, 0);
+        addSchema(DC_SCHEMA_URI, URI.create("file:" + Paths.get(LOCAL_DC_SCHEMA_PATH).toAbsolutePath()));
+
+        int parseIndex = module.parse(stream(DC_XML), info, 0);
 
         assertEquals(1, parseIndex);
         assertEquals(RepInfo.TRUE, info.getWellFormed());
 
-        parseIndex = module.parse(stream(xml), info, parseIndex);
+        parseIndex = module.parse(stream(DC_XML), info, parseIndex);
 
         assertEquals(0, parseIndex);
         assertEquals(RepInfo.TRUE, info.getWellFormed());
@@ -105,6 +114,8 @@ public class XmlModuleTest {
                 "</oai_dc:dc>";
         RepInfo info = new RepInfo("uri:test");
 
+        addSchema(DC_SCHEMA_URI, URI.create("file:" + Paths.get(LOCAL_DC_SCHEMA_PATH).toAbsolutePath()));
+
         int parseIndex = module.parse(stream(xml), info, 0);
 
         assertEquals(1, parseIndex);
@@ -117,8 +128,48 @@ public class XmlModuleTest {
         assertEquals(RepInfo.FALSE, info.getValid());
     }
 
+    @Test
+    public void validateXmlSucceedsWhenLocalRelativeSchema() {
+        RepInfo info = new RepInfo("uri:test");
+
+        addSchema(DC_SCHEMA_URI, URI.create(Paths.get(LOCAL_DC_SCHEMA_PATH).toAbsolutePath().toString()));
+
+        int parseIndex = module.parse(stream(DC_XML), info, 0);
+
+        assertEquals(1, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+
+        parseIndex = module.parse(stream(DC_XML), info, parseIndex);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.TRUE, info.getValid());
+    }
+
+    @Test
+    public void validateXmlSucceedsWhenLocalHttpSchema() {
+        RepInfo info = new RepInfo("uri:test");
+
+        addSchema(DC_SCHEMA_URI, URI.create("http://digital.library.wisc.edu/1711.dl/XMLSchema-SimpleDC"));
+
+        int parseIndex = module.parse(stream(DC_XML), info, 0);
+
+        assertEquals(1, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+
+        parseIndex = module.parse(stream(DC_XML), info, parseIndex);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.TRUE, info.getValid());
+    }
+
     private InputStream stream(String xml) {
         return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void addSchema(URI source, URI destination) {
+        module.param(String.format("schema=%s;%s", source, destination));
     }
 
 }

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/simpledc20021212.xsd
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/simpledc20021212.xsd
@@ -1,0 +1,76 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://purl.org/dc/elements/1.1/"
+           targetNamespace="http://purl.org/dc/elements/1.1/"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            Simple DC XML Schema, 2002-10-09
+            by Pete Johnston (p.johnston@ukoln.ac.uk),
+            Carl Lagoze (lagoze@cs.cornell.edu), Andy Powell (a.powell@ukoln.ac.uk),
+            Herbert Van de Sompel (hvdsomp@yahoo.com).
+            This schema defines terms for Simple Dublin Core, i.e. the 15
+            elements from the http://purl.org/dc/elements/1.1/ namespace, with
+            no use of encoding schemes or element refinements.
+            Default content type for all elements is xs:string with xml:lang
+            attribute available.
+
+            Supercedes version of 2002-03-12.
+            Amended to remove namespace declaration for http://www.w3.org/XML/1998/namespace namespace,
+            and to reference lang attribute via built-in xml: namespace prefix.
+            xs:appinfo also removed.
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+               schemaLocation="http://www.w3.org/2001/03/xml.xsd">
+    </xs:import>
+
+    <xs:element name="title" type="elementType"/>
+    <xs:element name="creator" type="elementType"/>
+    <xs:element name="subject" type="elementType"/>
+    <xs:element name="description" type="elementType"/>
+    <xs:element name="publisher" type="elementType"/>
+    <xs:element name="contributor" type="elementType"/>
+    <xs:element name="date" type="elementType"/>
+    <xs:element name="type" type="elementType"/>
+    <xs:element name="format" type="elementType"/>
+    <xs:element name="identifier" type="elementType"/>
+    <xs:element name="source" type="elementType"/>
+    <xs:element name="language" type="elementType"/>
+    <xs:element name="relation" type="elementType"/>
+    <xs:element name="coverage" type="elementType"/>
+    <xs:element name="rights" type="elementType"/>
+
+    <xs:group name="elementsGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="title"/>
+                <xs:element ref="creator"/>
+                <xs:element ref="subject"/>
+                <xs:element ref="description"/>
+                <xs:element ref="publisher"/>
+                <xs:element ref="contributor"/>
+                <xs:element ref="date"/>
+                <xs:element ref="type"/>
+                <xs:element ref="format"/>
+                <xs:element ref="identifier"/>
+                <xs:element ref="source"/>
+                <xs:element ref="language"/>
+                <xs:element ref="relation"/>
+                <xs:element ref="coverage"/>
+                <xs:element ref="rights"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="elementType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute ref="xml:lang" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
Previously, XML schemas could only be set by specifying local files on disk in the jhove config. Now, the same config accepts URLs.